### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["NikonTrigger.py", "github:sparkfun/Nikon-Trigger-for-MicroPython/NikonTrigger.py"],
+    ["NikonTimedTrigger.py", "github:sparkfun/Nikon-Trigger-for-MicroPython/NikonTimedTrigger.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).

With this change, users can install the module using: \

This PR is part of an effort to add package.json to popular MicroPython libraries.